### PR TITLE
chore(node-version): droped node v10 support

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: ['12.17', 12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - name: Setup node


### PR DESCRIPTION
and started running verification against node v16

BREAKING CHANGE: the minimum supported node version is now v12.17